### PR TITLE
Logging bug fix

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,4 +4,4 @@ from pydantic import BaseModel, HttpUrl
 
 class Services(BaseModel):
     """Services info."""
-    __root__: dict[str, list[HttpUrl]]
+    __root__: dict[str, list[dict]]

--- a/app/server.py
+++ b/app/server.py
@@ -60,7 +60,10 @@ for endpoint in endpoints:
         LOGGER.warning("Invalid URL '%s': %s", endpoint["url"], err)
         continue
     endpoint["url"] = base_url + "/query"
-    for operation in endpoint["operations"]:
+    
+    # Popped for cleanliness in /services enpoint
+    operations = endpoint.pop("operations") 
+    for operation in operations:
         SERVICES[operation].append(endpoint)
 SERVICES = dict(SERVICES)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,6 +29,20 @@ def test_query():
     response_json = response.json()
     assert len(response_json["message"]["results"]) == 1
 
+def test_services():
+    """Test calling /query endpoint."""
+    response = testclient.get("/services")
+    response.raise_for_status()
+    response_json = response.json()
+
+    # The response here should be a dict
+    # where keys are operations and values
+    # are a list of urls.
+    # This is a basic check
+    # We could go deeper and look for urls
+
+    assert isinstance(response_json, dict)
+
 
 def test_endpoint():
     """Test getting OpenAPI."""


### PR DESCRIPTION
In the recent overhaul of logging we broke the /services endpoint. Ultimately this was an outdated pydantic type check. This also adds a test of the /services endpoint.